### PR TITLE
Docker login before GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,12 @@ jobs:
         with:
           go-version: stable
 
+      - name: Docker registry login
+        run: make docker_login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_API_KEY: ${{ secrets.DOCKER_API_KEY }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -49,10 +55,4 @@ jobs:
         run: go list -m "github.com/divergentcodes/jwt-block@${{ github.ref_name }}"
         env:
           GOPROXY: proxy.golang.org
-
-      - name: Push Docker image
-        run: make docker-push
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_API_KEY: ${{ secrets.DOCKER_API_KEY }}
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,6 @@ snapshot:
 release:
 	./scripts/release.sh
 
-# Push the Docker image to the repository.
-docker_push:
-	./scripts/docker_push.sh
+# Login to the Docker registry.
+docker_login:
+	./scripts/docker_login.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is a standalone binary that requires a Redis instance to store the blocklist.
 Download the [binary release](https://github.com/DivergentCodes/jwt-block/releases) for your platform,
 and place it in the executable path.
 
-JWT Block is also available as a Docker image.
+JWT Block is also available as [a Docker image](https://hub.docker.com/r/divergentcodes/jwt-block).
 
 ```
 docker run -it --rm divergentcodes/jwt-block:latest

--- a/scripts/docker_login.sh
+++ b/scripts/docker_login.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Login to the Docker registry.
+echo "$DOCKER_API_KEY" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Push the created Docker image to the repository, with all associated tags.
-echo "$DOCKER_API_KEY" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker image push --all-tags divergentcodes/jwt-block


### PR DESCRIPTION
- Removes the bundled docker login + docker push.
- Just has docker login, before GoReleaser.
- Let GoReleaser handle the push.