### PR TITLE
feat(lambda): add AWS Lambda capability and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 ##########################################################
 
 examples/docker-compose/ui-app/config.json
-
+examples/aws-lambda-authorizer/bootstrap
 
 ##########################################################
 # Golang

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Divergent Codes LLC
+Copyright (c) 2024 Divergent Codes LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,9 @@ modcheck:
 build:
 	./scripts/build.sh
 
-# Local installation of existing built executable.
-_build_install:
+# Local installation of executable.
+install:
 	./scripts/install.sh
-
-# Local build and installation of executable.
-install: build _build_install
 
 # Build point-in-time snapshot release.
 snapshot:

--- a/README.md
+++ b/README.md
@@ -7,23 +7,37 @@ Exploring the feasability and performance of a JWT blocklist.
 
 ## About
 
-JWT Block is a blocklist & auth proxy service for JWTs, to support immediate termination of access, since access tokens cannot truly be revoked.
+JWT Block is a blocklist & forward auth proxy service for JWTs, to support
+immediatetermination of access, since access tokens cannot truly be revoked.
 
 It is a standalone binary that requires a Redis instance to store the blocklist.
 
+It can be run as a web service or an AWS Lambda authorizer.
+
 ## Installation
 
-Download the [binary release](https://github.com/DivergentCodes/jwtblock/releases) for your platform,
-and place it in the executable path.
+### Build From Source
 
-JWT Block is also available as [a Docker image](https://hub.docker.com/r/divergentcodes/jwtblock).
+1. Have a functional Golang development environment.
+2. Build and install: `make && make install`
+
+### Binary Release
+
+1. Download the [binary release](https://github.com/DivergentCodes/jwtblock/releases)
+for your platform
+2. Place the `jwtblock` binary in an executable path.
+
+### Docker
+
+JWT Block is available as [a Docker image](https://hub.docker.com/r/divergentcodes/jwtblock).
 
 ```
-docker run -it --rm divergentcodes/jwtblock:latest
+docker run --rm -it divergentcodes/jwtblock:latest
 ```
-
 
 ## Usage
+
+### CLI
 
 ```
 JWT Block is a blocklist & auth proxy service for JWTs, to support immediate termination of access, since access tokens cannot truly be revoked.
@@ -38,6 +52,7 @@ Available Commands:
   flush       Empty the blocklist
   help        Help about any command
   list        List blocked JWT hashes
+  openapi     Generate OpenAPI specs for jwtblock
   serve       Serve the web API
   status      Get status of the blocklist
   unblock     Unblock a JWT
@@ -47,23 +62,120 @@ Flags:
       --config string       config file (default is ./jwtblock.yaml)
       --debug               Enable debug mode
   -h, --help                help for jwtblock
-      --json                Use JSON output
+      --json                Use JSON log output
   -q, --quiet               Quiet CLI output
       --redis-dbnum int     Redis DB number
       --redis-host string   Redis host (default "localhost")
       --redis-noverify      Skip Redis TLS certificate verification
       --redis-pass string   Redis password
       --redis-port int      Redis port (default 6379)
-      --redis-tls           Connect to Redis over TLS (default true)
+      --redis-tls           Connect to Redis over TLS
       --redis-user string   Redis username
       --verbose             Verbose CLI output
 
 Use "jwtblock [command] --help" for more information about a command.
 ```
 
-## Configuration
+### API
 
-There are a few ways to configure JWT Block (in order of precedence):
+The web service listens on port `4474/tcp` by default. It has two primary
+API endpoints, one for adding tokens to the blocklist (e.g. "logout") and
+one to check whether a token is in the blocklist.
+
+- `POST /blocklist/block`
+- `GET /blocklist/check`
+
+Both endpoints parse the token from the `Authorization` header as a
+bearer token. No other parameters are needed.
+
+Start the web service with `jwtblock serve`.
+
+OpenAPI specs can be generated with `jwtblock openapi`.
+
+### AWS Lambda
+
+> [!TIP]
+> Check the full [AWS Lambda example](./examples/aws-lambda-authorizer/README.md).
+
+JWT Block can run as an AWS Lambda function that will handle the following events:
+- API Gateway AWS Proxy: handle HTTP requests from API Gateway to block a token.
+- API Gateway Authorizer: make authentication decisions for API Gateway, similar to "forward auth" proxies.
+
+### Configuration
+
+There are multiple ways to configure JWT Block (in order of precedence):
 - CLI argument flags.
 - Environment variables.
 - Configuration file.
+
+## Demo
+
+> [!TIP]
+> The easiest way to try JWT Block is to spin up the [Docker Compose example](./examples/docker-compose/README.md).
+
+Run a Redis instance and then start the web service with the `serve` subcommand.
+
+```sh
+$ docker run -d --rm -p6379:6379 redis:alpine
+402f9668087f59fa085f6bcf5f40db441291f74b6399023a17654575d6d1dc95
+
+$ jwtblock serve
+JWT Block 0.0.1-DEV-SNAPSHOT-c7d8e29 created by Jack Sullivan <jack@divergent.codes>
+
+Serving the jwtblock web API on :4474
+{"level":"info","message":"Serving web API","func":"HandleRequests","host":"","port":4474}
+```
+
+Send requests to the service to block a token and verify that it is blocked.
+
+```sh
+export JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNzIyNzIyODg4LCJleHAiOjE3MjI3MjY0ODh9.jPZiGRRudxPAku-FBiWHrxyn95Zj01Pm6ZiUw097fcE"
+
+$ curl -s -X GET http://jwtblock.localhost:4474/blocklist/check \
+  -H "Authorization: Bearer $JWT" \
+  | jq
+{
+  "message": "JWT is allowed",
+  "blocked": false,
+  "block_ttl_sec": -1,
+  "block_ttl_str": "",
+  "error": false
+}
+
+$ curl -s -X POST http://jwtblock.localhost:4474/blocklist/block \
+  -H "Authorization: Bearer $JWT" \
+  | jq
+{
+  "message": "Token blocked",
+  "error": false
+}
+
+$ curl -s -X GET http://jwtblock.localhost:4474/blocklist/check \
+  -H "Authorization: Bearer $JWT" \
+  | jq
+{
+  "message": "JWT is blocked",
+  "blocked": true,
+  "block_ttl_sec": 3463,
+  "block_ttl_str": "57m43s",
+  "error": false
+}
+```
+
+The blocklist can be managed with the CLI.
+
+```sh
+$ jwtblock --quiet status
+Blocklist size: 1
+
+$ jwtblock --quiet list
+{"level":"info","message":"Listed token hashes in the blocklist","size":1}
+0: b8a5471d47b724b277d4861db071ae817556655abd9f31ce7cfa8b055cf9e397
+
+$ jwtblock --quiet flush
+{"level":"info","message":"Flushed the blocklist","count":1,"result":{"message":"OK","count":1,"error":false}}
+Flushed 1 tokens from the blocklist
+
+$ jwtblock --quiet status
+Blocklist size: 0
+```

--- a/examples/aws-lambda-authorizer/.terraform.lock.hcl
+++ b/examples/aws-lambda-authorizer/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.5.0"
+  hashes = [
+    "h1:OTk41JfiDc1TVFTcRZ//4+jwPBIcWHXOwN29mjdOyug=",
+    "zh:3b5774d20e87058d6d67d9ad4ce3fc4a5f7ea7748d345fa6721e24a0cbb0a3d4",
+    "zh:3b94e706ac0f5151880ccc9e63d33c4113361f27e64224a942caa04a5a19cd44",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d7201858fa9376029818c9d017b4b53a933cea75480306b1122663d1e8eea2b",
+    "zh:8c8c7537978adf12271fe143f93b3587bb5dbabf8202ff49d0e3955b7bddc24b",
+    "zh:a5942584665a2689e73f3a3c43296adeaeb7e8698631d157419aa931ff856907",
+    "zh:a63673abdba624d60c84b819184fe86422bdbdf6bc73f68d903a7191aed32c00",
+    "zh:bcd1586cc32b263265e09e78f56dba3a6b6b19f5371c099a9d7a1bfe0b0667cc",
+    "zh:cc9e70e186e4dcef60208b4a64b42e6813b197e21ea106a96bb4eb23b54c3e44",
+    "zh:d4c8a0f69412892507a2c9ec0e334bcc2812a54b81212420d4f2c96ef58f713a",
+    "zh:e91e6d90bbc15252310eca6400d4188b29260aab0539480a3fc7b45e4d19c446",
+    "zh:fc468449c0dbda56aae6cb924e4a67578d18504b5b06e8989783182c6b4a5f73",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.61.0"
+  hashes = [
+    "h1:qYXhPfMOxgOYuSjfe7+P2wdqx4oMkPYgH4XUN3fJb54=",
+    "zh:1a0a150b6adaeacc8f56763182e76c6219ac67de1217b269d24b770067b7bab0",
+    "zh:1d9c3a8ac3934a147569254d6e2e6ea5293974d0595c02c9e1aa31499a8f0042",
+    "zh:1f4d1d5e2e02fd5cccafa28dade8735a3059ed1ca3284fb40116cdb67d0e7ee4",
+    "zh:26be6f759bded469de477f54c7eb7a9ca9f137a3b52f9fd26cbd864f16973912",
+    "zh:276e308ae7aa281fe24f7275673aa05f00cb830b83c2b9797f9aa55f10769c52",
+    "zh:45c09beeadb4269d518de0bd341cbe9f061157ab54c543d39168ecefff40bbe2",
+    "zh:58fb5ef076dc63e284ce28b47b7cc35a17d2596f11e2373fe568c6140277e9d8",
+    "zh:64d51cc1ad412379f64b75883a881a5d682a8e9737ad14479f6a2d62e77f7dbe",
+    "zh:71e2e332317cf095288d65a801e95b65fd696204997b2db5250862d6c5669518",
+    "zh:9864014aa4716b5bfb3b27d009f158dd6a67c215fd0dfbe3a5d1a7cee72c5677",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:d8bf9ba43bd938faab37d8fb515c32a905d6dace60f5ff2663b06ffdc89a62e9",
+    "zh:e654be9d3980e7cc70f9825fe0d0205e254edd87832f18b2d7f9c72b09b776cd",
+    "zh:ee5ce6fbe75be3e90cabba3fad76fcfde50ab795e523b4ee917cfe8ba8ad42fe",
+    "zh:ef12098e7b3ddf9ab286bb209de87dfa8e52106049ced0841e3e6487dbff3659",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.2"
+  hashes = [
+    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}

--- a/examples/aws-lambda-authorizer/Makefile
+++ b/examples/aws-lambda-authorizer/Makefile
@@ -1,0 +1,13 @@
+# Control the AWS Lambda Authorizor example.
+
+all: build deploy
+
+build:
+	cd ../../; GOOS="linux" GOARCH="amd64" bash ./scripts/build.sh
+
+deploy:
+	cp "../../dist/jwtblock_linux_amd64_v1/jwtblock" bootstrap
+	terraform apply
+
+stop:
+	echo "not implemented"

--- a/examples/aws-lambda-authorizer/README.md
+++ b/examples/aws-lambda-authorizer/README.md
@@ -1,0 +1,32 @@
+# JWT Block Example: AWS Lambda Authorizer
+
+This example demonstrates using JWT Block as a Lambda authorizer.
+It uses Terraform to provision an AWS environment:
+- Dedicated VPC and private subnets.
+- API Gateway that sends web requests to the Lambda if a custom authorizer approves.
+- Lambda function with the JWT Block binary.
+- Redis ElastiCache cluster for the blocklist.
+
+The Lambda function acts as both a web API endpoint (`POST /block`)
+and a [request-based](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html#api-gateway-lambda-authorizer-choose) Lambda authorizer for the API Gateway.
+
+A Lambda authorizer takes the caller's identity as the input and returns
+an IAM policy as the output. The API Gateway then evaluates the returned policy to allow or deny the request.
+
+## Usage
+
+Set the AWS profile to use as an environment variable and run `make`.
+This will build JWT Block, deploy it to AWS via Terraform, and
+provision all of the other necessary infrastructure for the example
+(e.g. Redis ElastiCache).
+
+```sh
+export AWS_PROFILE=myaccount
+make
+```
+
+
+## Resources
+
+- [Use API Gateway Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html) (Amazon)
+- [Control access to HTTP APIs with AWS Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html) (Amazon)

--- a/examples/aws-lambda-authorizer/apigateway_http.tf
+++ b/examples/aws-lambda-authorizer/apigateway_http.tf
@@ -1,0 +1,22 @@
+###########################################################
+# API Gateway (HTTP)
+###########################################################
+
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${var.project_name}-apigw-http"
+  description   = "APIGW v2 (HTTP) for Lambdas"
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_origins = [local.ui_origin]
+    allow_methods = ["GET", "POST", "OPTIONS"]
+    allow_headers = ["Authorization", "Content-Type"]
+    max_age = 3600  # Cache duration for preflight requests
+  }
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "main"
+  auto_deploy = true
+}

--- a/examples/aws-lambda-authorizer/cloudfront_ui.tf
+++ b/examples/aws-lambda-authorizer/cloudfront_ui.tf
@@ -1,0 +1,207 @@
+locals {
+  s3_origin_id = var.project_name
+
+  static_assets = [
+    {
+      source = "./ui-app/index.html",
+      dest   = "index.html",
+      mime   = "text/html",
+    },
+    {
+      source = "./ui-app/oauth2-callback.html",
+      dest   = "oauth2-callback.html",
+      mime   = "text/html",
+    },
+    {
+      source = "./ui-app/styles.css",
+      dest   = "styles.css",
+      mime   = "text/css",
+    },
+    {
+      source = "./ui-app/oidc.js",
+      dest   = "oidc.js",
+      mime   = "application/javascript",
+    },
+  ]
+}
+
+###########################################################
+# S3 Bucket
+###########################################################
+
+resource "aws_s3_bucket" "static_assets" {
+  bucket = var.project_name
+}
+
+###########################################################
+# Static Assets (UI)
+###########################################################
+
+resource "aws_s3_object" "ui_config" {
+  bucket = aws_s3_bucket.static_assets.id
+
+  content = templatefile("${path.module}/ui-app/config.json.tpl", {
+    oidc_client_id     = local.oidc_client_id
+    oidc_authorize_url = local.oidc_authorize_url
+    oidc_token_url     = local.oidc_token_url
+    oidc_callback_url  = local.oidc_callback_urls[0]
+    oidc_logout_url    = local.oidc_logout_urls[0]
+    protected_url      = local.protected_url
+  })
+
+  key          = "config.json"
+  content_type = "application/json"
+}
+
+resource "aws_s3_object" "static_assets" {
+  for_each = { for item in local.static_assets: item.dest => item }
+
+  bucket       = aws_s3_bucket.static_assets.id
+  source       = each.value.source
+  key          = each.value.dest
+  content_type = each.value.mime
+  etag         = filemd5(each.value.source)
+}
+
+###########################################################
+# Permissions
+###########################################################
+
+resource "aws_cloudfront_origin_access_identity" "static_assets" {
+  comment = var.project_name
+}
+
+resource "aws_s3_bucket_policy" "static_assets" {
+  bucket = aws_s3_bucket.static_assets.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${aws_cloudfront_origin_access_identity.static_assets.id}"
+        },
+        Action   = "s3:GetObject",
+        Resource = "${aws_s3_bucket.static_assets.arn}/*"
+      }
+    ]
+  })
+}
+
+###########################################################
+# Cloudfront
+###########################################################
+
+resource "aws_cloudfront_origin_access_control" "static_assets" {
+  name                              = var.project_name
+  description                       = "Policy for the web UI of ${var.project_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_response_headers_policy" "static_assets" {
+  name    = var.project_name
+  comment = var.project_name
+
+  cors_config {
+    access_control_allow_credentials = true
+
+    access_control_allow_origins {
+      items = ["*"]
+    }
+
+    access_control_allow_headers {
+      items = ["Authorization"]
+    }
+
+    access_control_allow_methods {
+      items = ["OPTIONS", "GET", "POST"]
+    }
+
+    origin_override = true
+  }
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override        = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security {
+      include_subdomains         = true
+      access_control_max_age_sec = "63072000"
+      override                   = true
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "static_assets" {
+  enabled             = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100"
+
+  origin {
+    origin_id                = local.s3_origin_id
+    domain_name              = aws_s3_bucket.static_assets.bucket_regional_domain_name
+
+    s3_origin_config {
+      origin_access_identity   = aws_cloudfront_origin_access_identity.static_assets.cloudfront_access_identity_path
+    }
+  }
+
+
+  default_cache_behavior {
+    target_origin_id           = local.s3_origin_id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.static_assets.id
+    viewer_protocol_policy     = "allow-all"
+    min_ttl                    = 0
+    default_ttl                = 1
+    max_ttl                    = 1
+
+    cached_methods   = [
+      "OPTIONS",
+      "HEAD",
+      "GET",
+    ]
+    allowed_methods  = [
+      "OPTIONS",
+      "HEAD",
+      "GET",
+      "POST",
+      "PUT",
+      "PATCH",
+      "DELETE",
+    ]
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/examples/aws-lambda-authorizer/cognito.tf
+++ b/examples/aws-lambda-authorizer/cognito.tf
@@ -1,0 +1,84 @@
+################################################################################
+# Variables
+################################################################################
+
+resource "random_id" "domain_suffix" {
+  byte_length = 8
+}
+
+locals {
+  cognito_user_pool_name  = "${var.project_name}-user-pool"
+  cognito_app_client_name = "${var.project_name}-app-client"
+  domain_prefix           = "${var.project_name}-${random_id.domain_suffix.hex}"
+}
+
+################################################################################
+# User Pool
+################################################################################
+
+resource "aws_cognito_user_pool" "main" {
+  name = local.cognito_user_pool_name
+
+  password_policy {
+    minimum_length    = 8
+    require_lowercase = false
+    require_numbers   = false
+    require_symbols   = false
+    require_uppercase = false
+  }
+
+  auto_verified_attributes = ["email"]
+}
+
+
+################################################################################
+# App Client
+################################################################################
+
+resource "aws_cognito_user_pool_client" "main" {
+  name         = local.cognito_app_client_name
+  user_pool_id = aws_cognito_user_pool.main.id
+
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = local.scopes
+  allowed_oauth_flows_user_pool_client = true
+
+  explicit_auth_flows = [
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_USER_PASSWORD_AUTH",
+  ]
+
+  callback_urls                = local.oidc_callback_urls
+  logout_urls                  = local.oidc_logout_urls
+  supported_identity_providers = ["COGNITO"]
+
+  generate_secret = false
+}
+
+
+################################################################################
+# Domain
+################################################################################
+
+resource "aws_cognito_user_pool_domain" "main" {
+  domain       = local.domain_prefix
+  user_pool_id = aws_cognito_user_pool.main.id
+}
+
+
+################################################################################
+# User
+################################################################################
+
+resource "aws_cognito_user" "bob" {
+  user_pool_id = aws_cognito_user_pool.main.id
+  username     = var.idp_demo_user.username
+  password     = var.idp_demo_user.password
+
+  attributes = {
+    email          = var.idp_demo_user.email
+    email_verified = true
+  }
+}

--- a/examples/aws-lambda-authorizer/lambda_jwtblock.tf
+++ b/examples/aws-lambda-authorizer/lambda_jwtblock.tf
@@ -1,0 +1,161 @@
+###########################################################
+# Security Group
+###########################################################
+
+resource "aws_security_group" "jwtblock_lambda" {
+  name        = "${var.project_name}-jwtblock-lambda-sg"
+  description = "The JWT Block Lambda endpoints and authorizer"
+  vpc_id      = local.vpc_id
+
+  tags = {
+    Name = "${var.project_name}-jwtblock-lambda-sg"
+  }
+}
+
+resource "aws_security_group_rule" "jwtblock_lambda_egress_all" {
+  security_group_id = aws_security_group.jwtblock_lambda.id
+
+  description = "Allow all JWT Block Lambda traffic out"
+  type        = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+###########################################################
+# IAM Role & Policy
+###########################################################
+
+resource "aws_iam_role" "jwtblock_lambda_role" {
+  name = "${var.project_name}-jwtblock-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "jwtblock_lambda_policy" {
+  role = aws_iam_role.jwtblock_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:AttachNetworkInterface",
+          "ec2:DetachNetworkInterface",
+        ]
+        Effect = "Allow"
+        Resource = "*"
+      },
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "jwtblock_lambda_exec_policy_attachment" {
+  role       = aws_iam_role.jwtblock_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+###########################################################
+# Lambda Function
+###########################################################
+
+data "archive_file" "jwtblock_lambda" {
+  # The binary must be named "bootstrap"
+  # https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html#golang-handler-naming
+  source_file = "./bootstrap"
+  output_path = "lambda_jwtblock.zip"
+  type        = "zip"
+}
+
+resource "aws_lambda_function" "jwtblock" {
+  description   = "JWT Block API endpoints and Lambda authorizer"
+  function_name = "${var.project_name}-authorizer"
+  role          = aws_iam_role.jwtblock_lambda_role.arn
+  handler       = "main"
+  filename      = "lambda_jwtblock.zip"
+  source_code_hash = data.archive_file.jwtblock_lambda.output_base64sha256
+  runtime       = "provided.al2023"
+
+  environment {
+    variables = {
+      JWTBLOCK_DEBUG                     = 1
+      JWTBLOCK_REDIS_HOST                = aws_elasticache_cluster.redis.cache_nodes[0].address
+      JWTBLOCK_REDIS_PORT                = var.redis_port
+      JWTBLOCK_HTTP_CORS_ALLOWED_ORIGINS = "https://${aws_cloudfront_distribution.static_assets.domain_name}"
+    }
+  }
+
+  vpc_config {
+    subnet_ids = [
+      aws_subnet.private_subnet_a.id,
+      aws_subnet.private_subnet_b.id,
+    ]
+
+    security_group_ids = [ aws_security_group.jwtblock_lambda.id ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.jwtblock_lambda_policy,
+    data.archive_file.jwtblock_lambda,
+  ]
+}
+
+###########################################################
+# API Gateway Endpoint (HTTP)
+###########################################################
+
+resource "aws_lambda_permission" "jwtblock" {
+  function_name = aws_lambda_function.jwtblock.function_name
+  statement_id  = "AllowAPIGatewayInvoke"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*/*"
+}
+
+resource "aws_apigatewayv2_integration" "jwtblock" {
+  description            = "APIGW v2 integration to the JWT Block Lambda handler"
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_uri        = aws_lambda_function.jwtblock.invoke_arn
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "jwtblock" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "ANY /blocklist"
+  target    = "integrations/${aws_apigatewayv2_integration.jwtblock.id}"
+}
+
+resource "aws_apigatewayv2_authorizer" "jwtblock" {
+  name                              = "${var.project_name}-authorizer"
+  api_id                            = aws_apigatewayv2_api.main.id
+  authorizer_uri                    = aws_lambda_function.jwtblock.invoke_arn
+  authorizer_type                   = "REQUEST"
+  identity_sources                  = ["$request.header.Authorization"]
+  authorizer_payload_format_version = "2.0"
+}

--- a/examples/aws-lambda-authorizer/lambda_protected.py
+++ b/examples/aws-lambda-authorizer/lambda_protected.py
@@ -1,0 +1,30 @@
+"""
+Lambda function that acts as a sensitive endpoint behind authentication.
+It always returns HTTP 200 with a JSON response.
+"""
+import json
+
+def lambda_handler(event, context):
+    print("event:", event)
+    print("context:", context)
+
+    headers = { k.lower():v for k,v in event['headers'].items() }
+    origin = headers.get("origin", "*")
+
+    response = {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+            "Access-Control-Allow-Methods": "*"
+        },
+    }
+
+    http_method = event['requestContext']['http']['method']
+    if http_method.lower() != 'options':
+        response['body'] = json.dumps({"message": "This endpoint is protected"})
+
+    print("response", response)
+
+    return response

--- a/examples/aws-lambda-authorizer/lambda_protected.tf
+++ b/examples/aws-lambda-authorizer/lambda_protected.tf
@@ -1,0 +1,142 @@
+###########################################################
+# Security Group
+###########################################################
+
+resource "aws_security_group" "protected_lambda" {
+  name        = "${var.project_name}-protected-lambda-sg"
+  description = "The protected Lambda API endpoints"
+  vpc_id      = local.vpc_id
+
+  tags = {
+    Name = "${var.project_name}-protected-lambda-sg"
+  }
+}
+
+resource "aws_security_group_rule" "protected_lambda_egress_all" {
+  security_group_id = aws_security_group.protected_lambda.id
+
+  description = "Allow all protected Lambda traffic out"
+  type        = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+###########################################################
+# IAM Role & Policy
+###########################################################
+
+resource "aws_iam_role" "protected_lambda_role" {
+  name = "${var.project_name}-protected-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "protected_lambda_policy" {
+  role = aws_iam_role.protected_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "protected_lambda_exec_policy_attachment" {
+  role       = aws_iam_role.protected_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+###########################################################
+# Lambda Function
+###########################################################
+
+data "archive_file" "protected_lambda" {
+  # The binary must be named "bootstrap"
+  # https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html#golang-handler-naming
+  source_file = "./lambda_protected.py"
+  output_path = "lambda_protected.zip"
+  type        = "zip"
+}
+
+resource "aws_lambda_function" "protected" {
+  description   = "Protected API endpoints"
+  function_name = "${var.project_name}-protected"
+  role          = aws_iam_role.protected_lambda_role.arn
+  handler       = "lambda_protected.lambda_handler"
+  filename      = "lambda_protected.zip"
+  source_code_hash = data.archive_file.protected_lambda.output_base64sha256
+  runtime       = "python3.12"
+
+  environment {
+    variables = {
+      LOG_LEVEL = "DEBUG"
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy.protected_lambda_policy,
+    data.archive_file.protected_lambda,
+  ]
+}
+
+###########################################################
+# API Gateway Endpoint (HTTP)
+###########################################################
+
+resource "aws_lambda_permission" "protected" {
+  function_name = aws_lambda_function.protected.function_name
+  statement_id  = "AllowAPIGatewayInvoke"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*/*"
+}
+
+resource "aws_apigatewayv2_integration" "protected" {
+  description            = "APIGW v2 integration to protected Lambda handler"
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_uri        = aws_lambda_function.protected.invoke_arn
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+# Allow preflight requests to protected endpoint without authentication.
+resource "aws_apigatewayv2_route" "protected_preflight" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "OPTIONS /protected"
+  target    = "integrations/${aws_apigatewayv2_integration.protected.id}"
+}
+
+# Require authentication for requests to protected endpoint.
+resource "aws_apigatewayv2_route" "protected_requests" {
+  for_each = toset(["GET", "POST"])
+
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "${each.value} /protected"
+  target    = "integrations/${aws_apigatewayv2_integration.protected.id}"
+
+  authorizer_id      = aws_apigatewayv2_authorizer.jwtblock.id
+  authorization_type = "CUSTOM"
+}

--- a/examples/aws-lambda-authorizer/main.tf
+++ b/examples/aws-lambda-authorizer/main.tf
@@ -1,0 +1,53 @@
+data "aws_region" "current" {}
+
+locals {
+  vpc_id = aws_vpc.main.id  
+
+  idp_origin   = "https://${aws_cognito_user_pool_domain.main.domain}.auth.${var.aws_region}.amazoncognito.com"
+  ui_origin    = "https://${aws_cloudfront_distribution.static_assets.domain_name}"
+  apigw_base_url = aws_apigatewayv2_stage.main.invoke_url
+
+  issuer         = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.main.id}"
+  jwks_url       = "${local.issuer}/.well-known/jwks.json"
+
+  oidc_client_id          = aws_cognito_user_pool_client.main.id
+  oidc_authorize_url      = "${local.idp_origin}/oauth2/authorize"
+  oidc_token_url          = "${local.idp_origin}/oauth2/token"
+  oidc_callback_urls      = ["${local.ui_origin}/oauth2-callback.html"]
+  oidc_logout_urls        = ["${local.apigw_base_url}/blocklist"]
+  scopes                  = ["openid", "profile", "email"]
+
+  protected_url = "${local.apigw_base_url}/protected"
+}
+
+###########################################################
+# Network
+###########################################################
+
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+resource "aws_subnet" "private_subnet_a" {
+  vpc_id            = local.vpc_id
+  cidr_block        = var.subnet_cidr["aza"]
+  availability_zone = "${var.aws_region}a"
+
+  tags = {
+    Name = "${var.project_name}-subnet-aza"
+  }
+}
+
+resource "aws_subnet" "private_subnet_b" {
+  vpc_id            = local.vpc_id
+  cidr_block        = var.subnet_cidr["azb"]
+  availability_zone = "${var.aws_region}b"
+
+  tags = {
+    Name = "${var.project_name}-subnet-azb"
+  }
+}

--- a/examples/aws-lambda-authorizer/outputs.tf
+++ b/examples/aws-lambda-authorizer/outputs.tf
@@ -1,0 +1,36 @@
+output "api_gatewayv2_http_base_url" {
+  description = "Base URL for the HTTP API Gateway v2 endpoints"
+  value       = local.apigw_base_url
+}
+
+output "cloudfront_ui_url" {
+  description = "Base URL for the Cloudfront UI app"
+  value       = local.ui_origin
+}
+
+output "ui_config_url" {
+  description = "UI config file"
+  value       = "${local.ui_origin}/config.json"
+}
+
+output "protected_url" {
+  value = local.protected_url
+}
+
+output "odic_issuer" {
+  value = local.issuer
+}
+
+output "jwks_url" {
+  value = local.jwks_url
+}
+
+output "oidc_configuration" {
+  value = {
+    client_id     = local.oidc_client_id
+    authorize_url = local.oidc_authorize_url
+    token_url     = local.oidc_token_url
+    callback_url  = local.oidc_callback_urls[0]
+    logout_url    = local.oidc_logout_urls[0]
+  }
+}

--- a/examples/aws-lambda-authorizer/providers.tf
+++ b/examples/aws-lambda-authorizer/providers.tf
@@ -1,0 +1,23 @@
+# providers.tf
+
+terraform {
+
+  required_version = "~> 1.9.0"
+
+  required_providers {
+  }
+
+}
+
+provider "aws" {
+
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy   = "terraform"
+      Name        = var.project_name
+      Project     = var.project_name
+    }
+  }
+}

--- a/examples/aws-lambda-authorizer/redis.tf
+++ b/examples/aws-lambda-authorizer/redis.tf
@@ -1,0 +1,67 @@
+###########################################################
+# Security Group
+###########################################################
+
+resource "aws_security_group" "redis" {
+  name        = "${var.project_name}-redis-sg"
+  description = "Redis traffic"
+  vpc_id      = local.vpc_id
+
+  tags = {
+    Name = "${var.project_name}-redis-sg"
+  }
+}
+
+resource "aws_security_group_rule" "redis_ingress_lambda" {
+  security_group_id = aws_security_group.redis.id
+
+  description = "Allow Lambda traffic into Redis"
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = var.redis_port
+  to_port     = var.redis_port
+
+  source_security_group_id = aws_security_group.jwtblock_lambda.id
+}
+
+resource "aws_security_group_rule" "redis_egress_all" {
+  security_group_id = aws_security_group.redis.id
+
+  description = "Allow all Redis traffic out"
+  type        = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+###########################################################
+# Redis Cluster (ElastiCache)
+###########################################################
+
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = "${var.project_name}-redis-subnet-group"
+  subnet_ids = [
+    aws_subnet.private_subnet_a.id,
+    aws_subnet.private_subnet_b.id,
+  ]
+
+  tags = {
+    Name = "${var.project_name}-redis-subnet-group"
+  }
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "${var.project_name}-redis-cluster"
+  engine               = "redis"
+  node_type            = "cache.t3.micro"
+  parameter_group_name = "default.redis7"
+  num_cache_nodes      = var.redis_node_count
+  port                 = var.redis_port
+  subnet_group_name    = aws_elasticache_subnet_group.redis_subnet_group.name
+  security_group_ids   = [aws_security_group.redis.id]
+
+  tags = {
+    Name = "${var.project_name}-redis-cluster"
+  }
+}

--- a/examples/aws-lambda-authorizer/ui-app/config.json.tpl
+++ b/examples/aws-lambda-authorizer/ui-app/config.json.tpl
@@ -1,0 +1,8 @@
+{
+  "clientId": "${oidc_client_id}",
+  "authorizeEndpoint": "${oidc_authorize_url}",
+  "callbackEndpoint": "${oidc_callback_url}",
+  "tokenEndpoint": "${oidc_token_url}",
+  "protectedEndpoint": "${protected_url}",
+  "logoutEndpoint": "${oidc_logout_url}"
+}

--- a/examples/aws-lambda-authorizer/ui-app/index.html
+++ b/examples/aws-lambda-authorizer/ui-app/index.html
@@ -1,0 +1,101 @@
+<html>
+
+<head>
+    <title>Demo OIDC UI App</title>
+    <meta charset="UTF-8">
+    <link rel="shortcut icon" href="#">
+    <link rel="stylesheet" href="styles.css">
+    <script src="/oidc.js"></script>
+</head>
+
+<body id="body">
+
+    <h1> Demo OIDC UI App </h1>
+
+    <h2> OIDC Identity Provider (IdP) Configuration </h2>
+    <section>
+        <button id="btnLogin" onclick="oidcLogin_initAuthCodeFlow()">Login</button>
+        <br/> <br/>
+
+        <label for="txtClientId">Client ID:</label>
+        <p id="txtClientId" name="txtClientId"></p>
+
+        <label for="txtAuthorizationEndpoint">Authorization Endpoint:</label>
+        <p id="txtAuthorizationEndpoint" name="txtAuthorizationEndpoint"></p>
+
+        <label for="txtCallbackEndpoint">Callback Endpoint:</label>
+        <p id="txtCallbackEndpoint" name="txtCallbackEndpoint"></p>
+
+        <label for="txtTokenEndpoint">Token Endpoint:</label>
+        <p id="txtTokenEndpoint" name="txtTokenEndpoint"></p>
+
+    </section>
+
+
+    <h2> API Data </h2>
+    <section>
+        <button id="btnCallProtectedApi" onclick="callProtectedApi()">Call API</button>
+        <br/>
+
+        <label for="txtProtectedEndpoint">Protected Endpoint:</label>
+        <p id="txtProtectedEndpoint" name="txtProtectedEndpoint"></p>
+
+        <label for="txtApiResponseStatus">Response Status:</label>
+        <p id="txtApiResponseStatus" name="txtApiResponseStatus"></p>
+
+    </section>
+
+
+    <h2> Logout (block JWT)</h2>
+    <section>
+        <button id="btnLogout" onclick="oidcLogout()">Logout</button>
+        <br/>
+
+        <label for="txtLogoutEndpoint">Logout Endpoint:</label>
+        <p id="txtLogoutEndpoint" name="txtLogoutEndpoint"></p>
+
+        <label for="txtBlockResponseStatus">Response Status:</label>
+        <p id="txtBlockResponseStatus" name="txtBlockResponseStatus"></p>
+
+    </section>
+
+
+    <h2> Tokens </h2>
+    <section>
+        <button id="btnReset" onclick="resetAppState()">Clear State</button>
+        <br/> <br/>
+
+        <h3>Access Token (Decoded)</h3>
+        <pre> <code id="codeAccessTokenDecoded"></code> </pre>
+
+        <h3>Access Token</h3>
+        <code id="codeAccessToken"></code>
+
+        <h3>ID Token (Decoded)</h3>
+        <pre> <code id="codeIdTokenDecoded"></code> </pre>
+
+        <h3>ID Token</h3>
+        <code id="codeIdToken"></code>
+
+        <h3>Refresh Token</h3>
+        <code id="codeRefreshToken"></code>
+
+    </section>
+
+<script>
+
+/*******************************************************************************
+ * Event listeners setup on each page load.
+ ******************************************************************************/
+
+// Trigger request handler on initial page load.
+document.addEventListener("DOMContentLoaded", (event) => {handleRequest(event)}, false);
+
+// Trigger request handler when front end fragment route changes due to user interaction.
+window.addEventListener("hashchange", (event) => {handleRequest(event)}, false);
+
+</script>
+
+</body>
+
+</html>

--- a/examples/aws-lambda-authorizer/ui-app/oauth2-callback.html
+++ b/examples/aws-lambda-authorizer/ui-app/oauth2-callback.html
@@ -1,0 +1,21 @@
+<html>
+
+<head>
+    <title>Demo OIDC UI App Callback</title>
+    <meta charset="UTF-8">
+    <link rel="shortcut icon" href="#">
+    <link rel="stylesheet" href="styles.css">
+    <script src="/oidc.js"></script>
+</head>
+
+<body id="body">
+
+    <h1> Demo OIDC UI App Callback </h1>
+
+<script>
+    document.addEventListener("DOMContentLoaded", (event) => {oidcLogin_callbackCodeTokenExchange(event)}, false);
+</script>
+
+</body>
+
+</html>

--- a/examples/aws-lambda-authorizer/ui-app/oidc.js
+++ b/examples/aws-lambda-authorizer/ui-app/oidc.js
@@ -1,0 +1,364 @@
+/*******************************************************************************
+ * OIDC and IdP Parameters.
+ ******************************************************************************/
+
+var oidcAuthParams = {
+    // Identify the target resources the token will be used to access.
+    audience: "jwtblock-demo",
+    // Use auth code grant.
+    responseType: "code",
+    // Signal to use OIDC, include email address, and use refresh tokens.
+    // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+    scope: "openid profile email",
+    // After successful login, have the IdP redirect back to this app with the auth code.
+    redirectUri: "",
+    // Random state.
+    // Set dynamically at runtime, with value in localstorage.
+    // Could also be a URL path or params to append with JS.
+    state: "",
+    // S256 mode.
+    codeChallengeMethod: "S256",
+    // Set dynamically at runtime, with value in localstorage.
+    codeChallenge: "",
+}
+
+var oidcTokenParams = {
+    // Auth code grant.
+    grantType: "authorization_code",
+    // Same redirect as used in the previous 'authorization' step.
+    redirectUri: "",
+    // Set dynamically at runtime, with value in localstorage from previous step.
+    codeVerifier: "",
+    // Set dynamically at runtime, with value received from IdP to exchange for token.
+    code: "",
+}
+
+/*******************************************************************************
+ * Initial request handling.
+ ******************************************************************************/
+
+// Initialize configuration values from `/config.json`.
+function initConfig() {
+    fetch("config.json")
+        .then(response => response.json())
+        .then(data => {
+            localStorage.setItem("client_id", data.clientId);
+            document.getElementById("txtClientId").innerText = data.clientId;
+
+            localStorage.setItem("authorization_endpoint", data.authorizeEndpoint);
+            document.getElementById("txtAuthorizationEndpoint").innerText = data.authorizeEndpoint;
+
+            localStorage.setItem("callback_endpoint", data.callbackEndpoint);
+            document.getElementById("txtCallbackEndpoint").innerText = data.callbackEndpoint;
+
+            localStorage.setItem("token_endpoint", data.tokenEndpoint);
+            document.getElementById("txtTokenEndpoint").innerText = data.tokenEndpoint;
+
+            localStorage.setItem("protected_endpoint", data.protectedEndpoint);
+            document.getElementById("txtProtectedEndpoint").innerText = data.protectedEndpoint;
+
+            localStorage.setItem("logout_endpoint", data.logoutEndpoint);
+            document.getElementById("txtLogoutEndpoint").innerText = data.logoutEndpoint;
+        });
+}
+
+// Handle a page load or redirect.
+function handleRequest(event) {
+    var oldUrl, newUrl;
+
+    // Parse the new URL from the event (initial load or transition).
+    switch(event.type) {
+        // Page load.
+        case "DOMContentLoaded":
+            oldUrl = null;
+            newUrl = new URL(document.location.href);
+            console.log(`Handling page load: [(none)] --> [${newUrl.hash}]`);
+            initConfig();
+            break;
+
+        // User page transition.
+        case "hashchange":
+            oldUrl = new URL(event.oldURL);
+            newUrl = new URL(event.newURL);
+            console.log(`Handling user page transition: [${oldUrl.hash}] --> [${newUrl.hash}]`);
+            break;
+
+        // JS page transition.
+        case "popstate":
+            console.log("Handling popstate event type");
+            break;
+
+        default:
+            console.log("Unhandled event type");
+    }
+
+    // Handle the route.
+    if ((document.location.pathname === "/oauth2/callback") || (newUrl.hash === "#/oauth2/callback")) {
+        // Browser page request was triggered by IdP,
+        // giving this page a code to exchange for an auth token.
+        oidcLogin_callbackCodeTokenExchange();
+    }
+
+    updatePage();
+}
+
+/*******************************************************************************
+ * API data functions.
+ ******************************************************************************/
+
+// Issue HTTP request to the protected API.
+function callProtectedApi() {
+    let protectedEndpoint = localStorage.getItem("protected_endpoint");
+    let accessToken = localStorage.getItem("access_token");
+    console.log(`Calling protected endpoint: ${protectedEndpoint}`);
+
+    // Assemble the request configuration.
+    let requestParams = {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${accessToken}`,
+        },
+        cache: "no-cache",
+        mode: "cors",
+    }
+
+    // Issue request.
+    fetch(protectedEndpoint, requestParams)
+        .then(response => {
+            console.log(response);
+            document.getElementById("txtApiResponseStatus").innerHTML = response.status;
+        }).catch( err => {
+            console.log("Error fetching protected API:", err)
+        })
+ }
+
+/*******************************************************************************
+ * Token functions.
+ ******************************************************************************/
+
+// Start the OIDC auth code flow by sending params to IdP and having user login.
+function oidcLogin_initAuthCodeFlow() {
+    let clientId = localStorage.getItem("client_id");
+    let authorizeEndpoint = localStorage.getItem("authorization_endpoint");
+    console.log(`Handling OIDC login , by redirecting to the IdP authorization endpoint: ${authorizeEndpoint}`);
+
+    // Get the callback URL to redirect to after successful login.
+    oidcAuthParams.redirectUri = localStorage.getItem("callback_endpoint");
+    console.log(`Redirect to callback URL: ${oidcAuthParams.redirectUri}`)
+
+    // State can include URL paths for the final resource.
+    // In production, should be dynamically generated instead of static.
+    oidcAuthParams.state = "foobarbaz";
+
+    // Client's generated code verifier proves to the IdP that it initiated the auth flow.
+    // In production, this should be a cryptographically random nonce, length (43, 128).
+    let codeVerifier = "_SqP8qgZiyRIAFiV-_HMmD9NshvB8k_tVQT-fJJPtNPCn4E7zWO6HZFQ-KAavMRF5cOomuMg46aU-tzQEcZIVXIFWhIEUFudYT38ZakMfm14r-L0dEZEc_T2FlHaSRcI";
+
+    // S256 mode: code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+    // https://www.rfc-editor.org/rfc/rfc7636#section-4
+    oidcAuthParams.codeChallenge = "WfAQIP_WPZCrIfUUbSr7fQhoTEez8cU7gybrmst79u0"
+
+    // Save the some values for later steps.
+    localStorage.setItem("oidc_state", oidcAuthParams.state);
+    localStorage.setItem("oidc_code_verifier", codeVerifier);
+
+    // Assemble the IdP login request URL.
+    let loginRequest = new URL(authorizeEndpoint);
+    loginRequest.searchParams.append("response_type", oidcAuthParams.responseType);
+    loginRequest.searchParams.append("scope", oidcAuthParams.scope);
+    loginRequest.searchParams.append("client_id", clientId);
+    loginRequest.searchParams.append("redirect_uri", oidcAuthParams.redirectUri);
+    loginRequest.searchParams.append("state", oidcAuthParams.state);
+    loginRequest.searchParams.append("code_challenge_method", oidcAuthParams.codeChallengeMethod);
+    loginRequest.searchParams.append("code_challenge", oidcAuthParams.codeChallenge);
+
+    console.log('Login request query parameters:');
+    console.log(loginRequest.searchParams);
+
+    // Issue the first HTTP request to the IdP, starting the auth code flow
+    // and returning the login pages.
+    window.location.href = loginRequest.href
+}
+
+// Check if browser page request was triggered by IdP, sending an auth code.
+function oidcLogin_callbackCodeTokenExchange() {
+    console.log("Callback: receiving auth code that can be exchanged for a token");
+
+    try {
+        // Callback and token endpoint.
+        let callbackEndpoint = localStorage.getItem("callback_endpoint");
+        let tokenEndpoint = localStorage.getItem("token_endpoint");
+        console.log("Callback URL: ", callbackEndpoint);
+        console.log("Token URL: ", tokenEndpoint);
+
+        // Client ID.
+        let clientId = localStorage.getItem("client_id");
+
+        // Auth code.
+        const callbackParams = new URLSearchParams(document.location.search);
+        let code = callbackParams.get("code");
+        if (!code) {
+            console.log("Missing OIDC 'code' parameter");
+            return;
+        }
+        console.log("Auth code: ", code);
+
+        // Code verifier.
+        codeVerifier = localStorage.getItem("oidc_code_verifier");
+        console.log("Code verifier: ", codeVerifier);
+
+        // Request to token endpoint must be 'application/x-www-form-urlencoded' (Cognito)
+        fetch(tokenEndpoint, {
+            method: 'POST',
+            headers:{
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: new URLSearchParams({
+                "client_id": clientId,
+                "grant_type": "authorization_code",
+                "redirect_uri": callbackEndpoint,
+                "code_verifier": codeVerifier,
+                "code": code,
+            })
+        }).then(response => response.json())
+        .then(data =>{
+            console.log("Token endpoint response data...")
+            console.log(data)
+
+            if (data.access_token) { localStorage.setItem("access_token", data.access_token); }
+            if (data.id_token) { localStorage.setItem("id_token", data.id_token); }
+            if (data.expires_in) { localStorage.setItem("expires_in", data.expires_in); }
+            if (data.refresh_token) { localStorage.setItem("refresh_token", data.refresh_token); }
+
+            localStorage.setItem("authenticated", true);
+
+            // Redirect to UI app home.
+            document.location.replace(`${document.location.origin}/`)
+        });
+
+    } catch(errorOuter) {
+        console.log("Callback: Caught outer error:", errorOuter)
+    }
+}
+
+
+// Logout from the application.
+function oidcLogout() {
+    console.log("Handling logout");
+
+    let accessToken = localStorage.getItem("access_token");
+    let logoutEndpoint = localStorage.getItem("logout_endpoint");
+    let logoutUrl = new URL(logoutEndpoint);
+
+    // Assemble the request configuration.
+    let requestParams = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${accessToken}`,
+        },
+        cache: "no-cache",
+        mode: "cors"
+    }
+
+    // Issue the POST request.
+    let fetchPromise = fetch(logoutUrl.href, requestParams)
+        .then(response => {
+            console.log(response);
+            document.getElementById("txtBlockResponseStatus").innerHTML = response.status;
+            localStorage.setItem("authenticated", false);
+        }).catch( err => {
+            console.log("Error fetching logout:", err)
+        });
+}
+
+
+// Reset the app and browser storage.
+function resetAppState() {
+    console.log("Handling app state reset");
+
+    localStorage.clear();
+    sessionStorage.clear();
+
+    initConfig();
+    updatePage();
+}
+
+/*******************************************************************************
+ * Utility functions.
+ ******************************************************************************/
+
+// Redirect the UI to a hash ("fragment") path.
+function uiRedirect(hashPath = "") {
+    // Does not trigger a hashchange event.
+    const originUrl = new URL(document.location.origin);
+    history.pushState({}, "", originUrl);
+    document.location.hash = hashPath;
+
+    updatePage();
+}
+
+// Adjust elements based on state.
+function updatePage() {
+
+    // Display refresh token, if present.
+    let refreshToken = localStorage.getItem("refresh_token");
+    if (refreshToken) {
+        document.getElementById("codeRefreshToken").innerText = refreshToken;
+    } else {
+        document.getElementById("codeRefreshToken").innerText = "";
+    }
+
+    // Display access token, if present.
+    let accessToken = localStorage.getItem("access_token")
+    if (accessToken) {
+        document.getElementById("codeAccessToken").innerText = accessToken;
+        decodedJwt = parseJwt(accessToken);
+        decodedJwtString = JSON.stringify(decodedJwt, null, 4);
+        document.getElementById("codeAccessTokenDecoded").innerText = decodedJwtString;
+    } else {
+        document.getElementById("codeAccessToken").innerText = "";
+        document.getElementById("codeAccessTokenDecoded").innerText = "";
+    }
+
+    // Display ID token, if present.
+    let idToken = localStorage.getItem("id_token")
+    if (idToken) {
+        document.getElementById("codeIdToken").innerText = idToken;
+        decodedJwt = parseJwt(idToken);
+        decodedJwtString = JSON.stringify(decodedJwt, null, 4);
+        document.getElementById("codeIdTokenDecoded").innerText = decodedJwtString;
+    } else {
+        document.getElementById("codeIdToken").innerText = "";
+        document.getElementById("codeIdTokenDecoded").innerText = "";
+    }
+}
+
+// Parse a JWT string to a decoded JSON object.
+function parseJwt (token) {
+
+    var base64Url = token.split('.')[0];
+    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+    jwtHeader = JSON.parse(jsonPayload);
+
+    var base64Url = token.split('.')[1];
+    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+    jwtBody = JSON.parse(jsonPayload);
+
+    if (jwtBody["iat"]) { jwtBody["iat"] = new Date(jwtBody["iat"] * 1000).toString(); }
+    if (jwtBody["exp"]) { jwtBody["exp"] = new Date(jwtBody["exp"] * 1000).toString(); }
+
+    result = {
+        "header": jwtHeader,
+        "body": jwtBody,
+    }
+
+    return result;
+}

--- a/examples/aws-lambda-authorizer/ui-app/styles.css
+++ b/examples/aws-lambda-authorizer/ui-app/styles.css
@@ -1,0 +1,22 @@
+section {
+  display: inline-block;
+  word-wrap: break-word;
+  border: solid;
+  padding: 10px;
+  width: 720px;
+}
+
+label {
+  display: inline-block;
+  width: 180px;
+}
+
+p {
+  display: inline-block;
+  width: 450px;
+}
+
+input[type="text"] {
+  display: inline-block;
+  width: 450px;
+}

--- a/examples/aws-lambda-authorizer/variables.tf
+++ b/examples/aws-lambda-authorizer/variables.tf
@@ -1,0 +1,49 @@
+# variables.tf
+
+variable "project_name" {
+  description = "The name of this project."
+  type        = string
+  default     = "jwtblock-lambda-example"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for the entire VPC"
+  type        = string
+  default     = "10.198.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "CIDR for subnets in each availability zone"
+  type        = map(string)
+  default     = {
+    aza = "10.198.1.0/24",
+    azb = "10.198.2.0/24",
+  }
+}
+
+variable "redis_port" {
+  description = "Redis service port"
+  type        = number
+  default     = 6379
+}
+
+variable "redis_node_count" {
+  description = "Redis nodes in the cluster"
+  type        = number
+  default     = 1
+}
+
+variable "idp_demo_user" {
+  description = "The demo user to login as"
+  default     = {
+    username  = "bob"
+    password  = "hunter22"
+    email     = "bob@example.com"
+  }
+}

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,9 +1,9 @@
-# Local Example Using Docker Compose
+# JWT Block Example: Docker Compose
 
 This example starts a series of Docker containers, including a demo UI app and an instance of JWT Block. An Nginx proxy accepts all incoming web connections for the `*.localhost` network. For calls to the protected API, `api.localhost`, Nginx will forward requests to JWT Block to check if the request token is both valid not blocked.
 
 
-## Quick Start
+## Usage
 
 Build the current code into a local Docker image, and serve the containers
 using Docker Compose. Use `CTRL-C` to shut the container down.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/aws/aws-lambda-go v1.47.0
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZp
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.33.0 h1:uvTF0EDeu9RLnUEG27Db5I68ESoIxTiXbNUiji6lZrA=
 github.com/alicebob/miniredis/v2 v2.33.0/go.mod h1:MhP4a3EU7aENRi9aO+tHfTBZicLqQevyi/DJpoj6mi0=
+github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
+github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/bool64/dev v0.2.35 h1:M17TLsO/pV2J7PYI/gpe3Ua26ETkzZGb+dC06eoMqlk=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/internal/blocklist/check.go
+++ b/internal/blocklist/check.go
@@ -17,12 +17,14 @@ type CheckResult struct {
 
 // CheckByJwt checks if a token's hash value is in the blocklist.
 //
-// The passed tokenString will be hashed and looked up.
+// The passed tokenString will be validated, hashed, and looked up.
 func CheckByJwt(redisDB *redis.Client, tokenString string) (CheckResult, error) {
 	// Parse, validate, verify the JWT.
 	var checkResult CheckResult
 	_, err := crypto.RunJwtChecks(tokenString)
 	if err != nil {
+		checkResult.IsError = true
+		checkResult.Message = err.Error()
 		return checkResult, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	cmd "github.com/divergentcodes/jwtblock/cmd/jwtblock"
 	"github.com/divergentcodes/jwtblock/internal/core"
+	awslambda "github.com/divergentcodes/jwtblock/serverless/awslambda"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -12,15 +14,21 @@ func init() {
 	core.InitConfigDefaults()
 
 	logger.Debug("Initialized default configuration")
-}
 
-func main() {
-	runCli()
+	logger.Debug(viper.AllSettings())
 }
 
 func runCli() {
 	err := cmd.Execute()
 	if err != nil {
 		panic(err)
+	}
+}
+
+func main() {
+	if awslambda.IsAwsLambdaEnv() {
+		awslambda.Start()
+	} else {
+		runCli()
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Locally "install" the application by copying the binary to the GOPATH.
 # Get the binary name from the GoReleaser configuration file.
 
-binary_name=$(grep "project_name" .goreleaser.yaml | sed 's/project_name:[[:space:]]\+//')
+binary_name=$(grep "project_name:" .goreleaser.yaml | awk '{print $2}')
 echo "BIN:   [$binary_name]"
 
 os=$(go env GOOS)

--- a/serverless/awslambda/authorizerevent.go
+++ b/serverless/awslambda/authorizerevent.go
@@ -1,0 +1,169 @@
+package awslambda
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/divergentcodes/jwtblock/internal/blocklist"
+	"github.com/divergentcodes/jwtblock/internal/cache"
+	"github.com/divergentcodes/jwtblock/internal/core"
+)
+
+// Generate an IAM policy to return in the response.
+func generatePolicyResponse(principalId, effect, resourceArn string, checkResult blocklist.CheckResult) events.APIGatewayCustomAuthorizerResponse {
+	logger := core.GetLogger()
+
+	authResponse := events.APIGatewayCustomAuthorizerResponse{PrincipalID: principalId}
+
+	if effect != "" && resourceArn != "" {
+		authResponse.PolicyDocument = events.APIGatewayCustomAuthorizerPolicy{
+			Version: "2012-10-17",
+			Statement: []events.IAMPolicyStatement{
+				{
+					Action:   []string{"execute-api:Invoke"},
+					Effect:   effect,
+					Resource: []string{resourceArn},
+				},
+			},
+		}
+	}
+
+	// Add check result structure to response context.
+	authResponse.Context = map[string]interface{}{
+		"message":       checkResult.Message,
+		"blocked":       checkResult.IsBlocked,
+		"block_ttl_sec": checkResult.TTL,
+		"block_ttl_str": checkResult.TTLString,
+		"error":         checkResult.IsError,
+	}
+
+	logger.Debugw(
+		"generated authorizer response",
+		"func", "generatedPolicyResponse",
+		"effect", effect,
+		"resourceArn", resourceArn,
+		"response", authResponse,
+	)
+
+	return authResponse
+}
+
+func handleAuthorizerTypeRequestEvent(ctx context.Context, event events.APIGatewayV2CustomAuthorizerV2Request) (events.APIGatewayCustomAuthorizerResponse, error) {
+	logger := core.GetLogger()
+
+	if strings.ToLower(event.Type) != "request" {
+		logger.Errorw(
+			"event type is not 'token'",
+			"func", "awslambda.handleAuthorizerTypeTokenEvent",
+			"err", ErrLambdaAuth500AuthConfig.Error(),
+		)
+		return events.APIGatewayCustomAuthorizerResponse{}, ErrLambdaAuth500AuthConfig
+	}
+
+	token, tokenErr := getBearerToken(event.Headers)
+	if tokenErr != nil {
+		logger.Errorw(
+			"token parsing failed",
+			"func", "awslambda.handleAuthorizerTypeRequestEvent",
+			"err", ErrLambdaAuth401Unauthorized.Error(),
+		)
+		return events.APIGatewayCustomAuthorizerResponse{}, ErrLambdaAuth401Unauthorized
+	}
+	logger.Debugw(
+		"received token in Lambda event",
+		"func", "awslambda.handleAuthorizerTypeRequestEvent",
+		"token", token,
+	)
+
+	// Token validation and blocklist lookup.
+	redisClient := cache.GetRedisClient()
+	checkResult, err := blocklist.CheckByJwt(redisClient, token)
+	if err != nil {
+		logger.Errorw(
+			"token check failed",
+			"func", "awslambda.handleAuthorizerTypeRequestEvent",
+			"err", err.Error(),
+		)
+	}
+
+	// Response generation.
+	var response events.APIGatewayCustomAuthorizerResponse
+	var action string
+	if checkResult.IsBlocked || err != nil {
+		action = "Deny"
+		// This is how to define status codes returned by AWS Lambda Authorizers.
+		err = ErrLambdaAuth401Unauthorized
+	} else {
+		action = "Allow"
+		err = nil
+	}
+	response = generatePolicyResponse("user", action, event.RouteArn, checkResult)
+	logger.Debugw(
+		"lambda authorizer response generated",
+		"func", "awslambda.handleAuthorizerTypeRequestEvent",
+		"action", action,
+	)
+
+	return response, err
+}
+
+func handleAuthorizerTypeTokenEvent(ctx context.Context, event events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error) {
+	logger := core.GetLogger()
+
+	if strings.ToLower(event.Type) != "token" {
+		logger.Errorw(
+			"event type is not 'token'",
+			"func", "awslambda.handleAuthorizerTypeTokenEvent",
+			"err", ErrLambdaAuth500AuthConfig.Error(),
+		)
+		return events.APIGatewayCustomAuthorizerResponse{}, ErrLambdaAuth500AuthConfig
+	}
+	token := event.AuthorizationToken
+	if token == "" {
+		logger.Errorw(
+			"empty token value",
+			"func", "awslambda.handleAuthorizerTypeTokenEvent",
+			"err", ErrLambdaAuth401Unauthorized.Error(),
+		)
+		return events.APIGatewayCustomAuthorizerResponse{}, ErrLambdaAuth401Unauthorized
+	}
+	logger.Debugw(
+		"received token in Lambda event",
+		"func", "awslambda.handleAuthorizerTypeTokenEvent",
+		"token", token,
+	)
+
+	// Token validation and blocklist lookup.
+	redisClient := cache.GetRedisClient()
+	checkResult, err := blocklist.CheckByJwt(redisClient, token)
+	if err != nil {
+		logger.Errorw(
+			"token check failed",
+			"func", "awslambda.handleAuthorizerTypeTokenEvent",
+			"err", err.Error(),
+		)
+	}
+
+	// Response generation.
+	var response events.APIGatewayCustomAuthorizerResponse
+	var action string
+	if checkResult.IsBlocked || err != nil {
+		action = "Deny"
+		// This is how to define status codes returned by AWS Lambda Authorizers.
+		err = ErrLambdaAuth401Unauthorized
+	} else {
+		action = "Allow"
+		err = nil
+	}
+	response = generatePolicyResponse("user", action, event.MethodArn, checkResult)
+	logger.Debugw(
+		"lambda authorizer response generated",
+		"func", "awslambda.handleAuthorizerTypeTokenEvent",
+		"action", action,
+		"err", err.Error(),
+	)
+
+	return response, err
+}

--- a/serverless/awslambda/httpproxyeventv1.go
+++ b/serverless/awslambda/httpproxyeventv1.go
@@ -1,0 +1,124 @@
+package awslambda
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/divergentcodes/jwtblock/internal/blocklist"
+	"github.com/divergentcodes/jwtblock/internal/cache"
+	"github.com/divergentcodes/jwtblock/internal/core"
+)
+
+// Handle API Gateway V1 (REST) request events
+func handleHttpProxyEventV1(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	logger := core.GetLogger()
+	var response events.APIGatewayProxyResponse
+	responseHeaders := make(map[string]string)
+	httpMethod := strings.ToUpper(event.HTTPMethod)
+	origin, _ := getHeaderValue(event.Headers, "origin")
+
+	// Handle CORS preflight requests.
+	if strings.EqualFold(httpMethod, http.MethodOptions) {
+		logger.Debugw(
+			"received OPTIONS preflight request",
+			"func", "awslambda.handleHttpProxyEventV1",
+		)
+		response = events.APIGatewayProxyResponse{
+			StatusCode: http.StatusOK,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+		}
+		return response, nil
+	} else {
+		responseHeaders["Content-Type"] = "application/json"
+	}
+
+	// Only allow POST.
+	if !strings.EqualFold(httpMethod, http.MethodPost) {
+		logger.Warnw(
+			"invalid HTTP method",
+			"func", "awslambda.handleHttpProxyEventV1",
+			"method", httpMethod,
+		)
+		response = events.APIGatewayProxyResponse{
+			StatusCode: http.StatusMethodNotAllowed,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+		}
+		return response, nil
+	}
+
+	// Get token from headers.
+	tokenString, tokenErr := getBearerToken(event.Headers)
+
+	// No token found in headers. Unauthorized.
+	if tokenErr != nil || tokenString == "" {
+		msg := "failed to get token from request headers"
+		logger.Errorw(
+			msg,
+			"func", "awslambda.handleHttpProxyEventV1",
+			"tokenError", tokenErr.Error(),
+		)
+		response = events.APIGatewayProxyResponse{
+			StatusCode: http.StatusUnauthorized,
+			Headers:    responseHeaders,
+			Body:       tokenErr.Error(),
+		}
+		return response, tokenErr
+	}
+	logger.Debugw(
+		"Received value to add",
+		"func", "awslambda.handleHttpProxyEventV1",
+		"token", tokenString,
+	)
+
+	// Add value to the blocklist.
+	redisClient := cache.GetRedisClient()
+	blockResult, err := blocklist.Block(redisClient, tokenString)
+	if err != nil {
+		// Error is either token format (400), or server issue (500).
+		httpStatus := http.StatusBadRequest
+		if strings.Contains(strings.ToLower(err.Error()), "cache") {
+			httpStatus = http.StatusInternalServerError
+		}
+		logger.Errorw(
+			"Error adding token to blocklist",
+			"func", "awslambda.handleHttpProxyEventV1",
+			"result", blockResult,
+			"err", err,
+		)
+		jsonData, err := json.Marshal(blockResult)
+		response = events.APIGatewayProxyResponse{
+			StatusCode: httpStatus,
+			Headers:    responseHeaders,
+			Body:       string(jsonData),
+		}
+		return response, err
+	}
+
+	// Successful block
+	jsonData, err := json.Marshal(blockResult)
+	if err != nil {
+		errMsg := "Error marshaling blockResult to JSON"
+		logger.Errorw(
+			errMsg,
+			"func", "awslambda.handleHttpProxyEventV1",
+			"err", err,
+		)
+		response = events.APIGatewayProxyResponse{
+			StatusCode: http.StatusInternalServerError,
+			Headers:    responseHeaders,
+			Body:       errMsg,
+		}
+		return response, err
+	}
+	response = events.APIGatewayProxyResponse{
+		StatusCode: http.StatusOK,
+		Headers:    responseHeaders,
+		Body:       string(jsonData),
+	}
+
+	return response, nil
+}

--- a/serverless/awslambda/httpproxyeventv2.go
+++ b/serverless/awslambda/httpproxyeventv2.go
@@ -1,0 +1,125 @@
+package awslambda
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/divergentcodes/jwtblock/internal/blocklist"
+	"github.com/divergentcodes/jwtblock/internal/cache"
+	"github.com/divergentcodes/jwtblock/internal/core"
+)
+
+// Handle API Gateway V2 (HTTP) request events
+func handleHttpProxyEventV2(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	logger := core.GetLogger()
+	var response events.APIGatewayV2HTTPResponse
+	responseHeaders := make(map[string]string)
+	httpMethod := event.RequestContext.HTTP.Method
+	origin, _ := getHeaderValue(event.Headers, "origin")
+
+	// Handle CORS preflight requests.
+	if strings.EqualFold(httpMethod, http.MethodOptions) {
+		logger.Debugw(
+			"received OPTIONS preflight request",
+			"func", "awslambda.handleHttpProxyEventV2",
+		)
+		response = events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusOK,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+		}
+		return response, nil
+	} else {
+		responseHeaders["Content-Type"] = "application/json"
+	}
+
+	// Only allow POST.
+	if !strings.EqualFold(httpMethod, http.MethodPost) {
+		logger.Warnw(
+			"invalid HTTP method",
+			"func", "awslambda.handleHttpProxyEventV2",
+			"method", httpMethod,
+		)
+		response = events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusMethodNotAllowed,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+		}
+		return response, nil
+	}
+
+	// Get token from headers.
+	tokenString, tokenErr := getBearerToken(event.Headers)
+
+	// No token found in headers. Unauthorized.
+	if tokenErr != nil || tokenString == "" {
+		msg := "failed to get token from request headers"
+		logger.Errorw(
+			msg,
+			"func", "awslambda.handleHttpProxyEventV2",
+			"tokenError", tokenErr.Error(),
+		)
+
+		response = events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusUnauthorized,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+			Body:       tokenErr.Error(),
+		}
+		return response, tokenErr
+	}
+	logger.Debugw(
+		"received value to add",
+		"func", "awslambda.handleHttpProxyEventV2",
+		"token", tokenString,
+	)
+
+	// Add value to the blocklist.
+	redisClient := cache.GetRedisClient()
+	blockResult, err := blocklist.Block(redisClient, tokenString)
+	if err != nil {
+		// Error is either token format (400), or server issue (500).
+		httpStatus := http.StatusBadRequest
+		if strings.Contains(strings.ToLower(err.Error()), "cache") {
+			httpStatus = http.StatusInternalServerError
+		}
+		logger.Errorw(
+			"error adding token to blocklist",
+			"func", "awslambda.handleHttpProxyEventV2",
+			"result", blockResult,
+			"err", err,
+		)
+		jsonData, err := json.Marshal(blockResult)
+		response = events.APIGatewayV2HTTPResponse{
+			StatusCode: httpStatus,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+			Body:       string(jsonData),
+		}
+		return response, err
+	}
+
+	// Successful block
+	jsonData, err := json.Marshal(blockResult)
+	if err != nil {
+		errMsg := "error marshaling blockResult to JSON"
+		logger.Errorw(
+			errMsg,
+			"func", "awslambda.handleHttpProxyEventV2",
+			"err", err,
+		)
+		response = events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+			Body:       errMsg,
+		}
+		return response, err
+	}
+	response = events.APIGatewayV2HTTPResponse{
+		StatusCode: http.StatusOK,
+		Headers:    makeCorsPreflightHeaders(origin, responseHeaders),
+		Body:       string(jsonData),
+	}
+
+	return response, nil
+}

--- a/serverless/awslambda/root.go
+++ b/serverless/awslambda/root.go
@@ -1,0 +1,104 @@
+package awslambda
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/divergentcodes/jwtblock/internal/core"
+)
+
+// General error messages returned by the web service.
+var (
+	//lint:ignore ST1005 AWS Lambda behavior requires capitalization
+	ErrLambdaAuth500AuthConfig   = errors.New("Internal Server Error")
+	ErrLambdaAuth401Unauthorized = errors.New("Unauthorized")
+
+	ErrMissingTokenHeader = errors.New("missing HTTP header with token")
+	ErrMissingHashHeader  = errors.New("missing HTTP header with hash")
+
+	ErrMissingInvalidToken = errors.New("missing or invalid token value in request")
+	ErrMissingInvalidHash  = errors.New("missing or invalid hash value in request")
+
+	ErrMalformedBearerTokenFormat = errors.New("malformed bearer token format")
+)
+
+// Entry point to handle the incoming events.
+func HandleLambdaEvent(ctx context.Context, event json.RawMessage) (interface{}, error) {
+	logger := core.GetLogger()
+
+	logger.Debugw(
+		"Lambda Event",
+		"func", "awslambda.HandleLambdaEvent",
+		"rawEvent", event,
+		"rawContext", ctx,
+	)
+
+	// Check event type.
+	var authorizerTypeRequestEvent events.APIGatewayV2CustomAuthorizerV2Request
+	var authorizerTypeTokenEvent events.APIGatewayCustomAuthorizerRequest
+	var httpProxyRequestEventV1 events.APIGatewayProxyRequest
+	var httpProxyRequestEventV2 events.APIGatewayV2HTTPRequest
+	if err := json.Unmarshal(event, &authorizerTypeRequestEvent); err == nil && strings.ToLower(authorizerTypeRequestEvent.Type) == "request" {
+		logger.Debugw(
+			"Lambda Event",
+			"func", "awslambda.HandleLambdaEvent",
+			"type", "authorizerTypeRequestEvent",
+			"event", authorizerTypeRequestEvent,
+			"context", ctx,
+		)
+		return handleAuthorizerTypeRequestEvent(ctx, authorizerTypeRequestEvent)
+	} else if err := json.Unmarshal(event, &authorizerTypeTokenEvent); err == nil && strings.ToLower(authorizerTypeTokenEvent.Type) == "token" {
+		logger.Debugw(
+			"Lambda Event",
+			"func", "awslambda.HandleLambdaEvent",
+			"type", "authorizerTypeTokenEvent",
+			"event", authorizerTypeTokenEvent,
+			"context", ctx,
+		)
+		return handleAuthorizerTypeTokenEvent(ctx, authorizerTypeTokenEvent)
+	} else if err := json.Unmarshal(event, &httpProxyRequestEventV1); err == nil && httpProxyRequestEventV1.HTTPMethod != "" {
+		logger.Debugw(
+			"Lambda Event",
+			"func", "awslambda.HandleLambdaEvent",
+			"type", "httpProxyRequestEventV1",
+			"event", httpProxyRequestEventV1,
+			"context", ctx,
+		)
+		return handleHttpProxyEventV1(ctx, httpProxyRequestEventV1)
+	} else if err := json.Unmarshal(event, &httpProxyRequestEventV2); err == nil && httpProxyRequestEventV2.Version == "2.0" {
+		logger.Debugw(
+			"Lambda Event",
+			"func", "awslambda.HandleLambdaEvent",
+			"type", "httpProxyRequestEventV2",
+			"event", httpProxyRequestEventV2,
+			"context", ctx,
+		)
+		return handleHttpProxyEventV2(ctx, httpProxyRequestEventV2)
+	}
+
+	logger.Warnw(
+		"Unknown Lambda event type",
+		"func", "awslambda.HandleLambdaEvent",
+		"event", event,
+		"context", ctx,
+	)
+	return nil, fmt.Errorf("invalid Lambda event type")
+}
+
+// Check if the runtime environment is AWS Lambda.
+func IsAwsLambdaEnv() bool {
+	_, isLambda := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME")
+	return isLambda
+}
+
+// Start the Lambda handler.
+func Start() {
+	lambda.Start(HandleLambdaEvent)
+}

--- a/serverless/awslambda/utils.go
+++ b/serverless/awslambda/utils.go
@@ -1,0 +1,65 @@
+package awslambda
+
+import (
+	"strings"
+
+	"github.com/divergentcodes/jwtblock/internal/core"
+)
+
+func getHeaderValue(headers map[string]string, headerName string) (string, bool) {
+	logger := core.GetLogger()
+
+	for key, value := range headers {
+		if strings.EqualFold(headerName, key) {
+			logger.Debugw(
+				"Found header",
+				"func", "awslambda.getHeaderValue",
+				"headerName", headerName,
+				"headers", headers,
+			)
+			return value, true
+		}
+	}
+
+	logger.Debugw(
+		"Did not find header",
+		"func", "awslambda.getHeaderValue",
+		"headerName", headerName,
+		"headers", headers,
+	)
+
+	return "", false
+}
+
+func getBearerToken(headers map[string]string) (string, error) {
+	logger := core.GetLogger()
+
+	value, found := getHeaderValue(headers, "authorization")
+	if !found {
+		logger.Debugw(
+			ErrMissingTokenHeader.Error(),
+			"func", "awslambda.getBearerToken",
+		)
+		return value, ErrMissingTokenHeader
+	}
+
+	// Extract the bearer token value.
+	substrings := strings.Split(value, " ")
+	if len(substrings) != 2 {
+		logger.Debugw(
+			ErrMalformedBearerTokenFormat.Error(),
+			"func", "awslambda.getBearerToken",
+		)
+		return value, ErrMalformedBearerTokenFormat
+	}
+
+	value = substrings[1]
+	if value == "" {
+		logger.Debugw(
+			ErrMissingInvalidToken.Error(),
+			"func", "awslambda.getBearerToken",
+		)
+		return value, ErrMissingInvalidToken
+	}
+	return value, nil
+}

--- a/web/block.go
+++ b/web/block.go
@@ -65,7 +65,7 @@ func jwtBlock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Response.
-	WriteSuccessResponse(r, w, result.Message, 200)
+	WriteSuccessResponse(r, w, result.Message, http.StatusOK)
 }
 
 // OpenAPI documentation generation.

--- a/web/check.go
+++ b/web/check.go
@@ -58,7 +58,7 @@ func jwtCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Blocklist lookup.
-	redisDB := cache.GetRedisClient()
+	redisClient := cache.GetRedisClient()
 	if tokenString != "" {
 		// Lookup by JWT.
 		logger.Debugw(
@@ -66,7 +66,7 @@ func jwtCheck(w http.ResponseWriter, r *http.Request) {
 			"func", "web.jwtCheck",
 			"token", tokenString,
 		)
-		result, err = blocklist.CheckByJwt(redisDB, tokenString)
+		result, err = blocklist.CheckByJwt(redisClient, tokenString)
 	} else if hashString != "" {
 		// Lookup by SHA256 hash.
 		hashHeaderName := viper.GetString(core.OptStr_HttpHeaderSha256)
@@ -76,7 +76,7 @@ func jwtCheck(w http.ResponseWriter, r *http.Request) {
 			"func", "web.jwtCheck",
 			"sha256", hashString,
 		)
-		result, err = blocklist.CheckBySha256(redisDB, hashString)
+		result, err = blocklist.CheckBySha256(redisClient, hashString)
 	}
 
 	// Handle lookup errors.


### PR DESCRIPTION
This PR allows JWT Block to run as an AWS Lambda authorizer connected to an API Gateway.

- `REQUEST` based Lambda authorizer.
-  Full example with Terraform deployment, AWS Cognito, and a UI app.